### PR TITLE
feat: add multi-machine dotfiles support (go4dot-9wa.3)

### DIFF
--- a/cmd/g4d/detect.go
+++ b/cmd/g4d/detect.go
@@ -28,7 +28,11 @@ var detectCmd = &cobra.Command{
 		if p.DistroVersion != "" {
 			fmt.Printf("Version:         %s\n", p.DistroVersion)
 		}
+		fmt.Printf("Architecture:    %s\n", p.Architecture)
 		fmt.Printf("Package Manager: %s\n", p.PackageManager)
+		if p.Hostname != "" {
+			fmt.Printf("Hostname:        %s\n", p.Hostname)
+		}
 		if p.IsWSL {
 			ui.Info("Running inside WSL")
 		}

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -31,6 +31,10 @@ machine_config:
   # Prompts and templates for machine-specific files
   ...
 
+machines:
+  # Per-machine profiles for multi-machine setups
+  ...
+
 archived:
   # Old configs kept for documentation
   ...
@@ -101,13 +105,36 @@ configs:
       description: Git config
       platforms: [linux, macos]
       requires_machine_config: true  # Wait for machine config before stowing?
-      
+
   optional:
     - name: i3
       path: i3
       description: i3 Window Manager
       platforms: [linux]      # Only show on Linux
       depends_on: [xorg]      # informational dependency
+
+    - name: kde
+      path: kde
+      description: KDE Plasma settings
+      condition:              # Fine-grained conditions (more flexible than platforms)
+        hostname: fedora-workstation
+```
+
+**Condition vs Platforms:** The `platforms` field is a simple OS filter. The `condition` field supports all condition keys (os, distro, hostname, arch, wsl, package_manager) and can be combined. Both are checked if present.
+
+### Dependencies (Conditional)
+
+Dependencies can have conditions to only install on specific platforms or machines:
+
+```yaml
+dependencies:
+  core:
+    - name: plasma-desktop
+      condition:
+        distro: fedora
+    - name: hyprland
+      condition:
+        hostname: cachyos-laptop
 ```
 
 ### External
@@ -125,6 +152,7 @@ external:
     condition:                # Optional conditions
       os: linux
       distro: fedora
+      hostname: my-laptop     # Machine-specific
       wsl: true
       architecture: amd64
 ```
@@ -167,6 +195,46 @@ machine_config:
 - `text`: Free-form text input (default).
 - `confirm`: Yes/no boolean prompt.
 - `select`: Selection from predefined options (falls back to text input).
+
+### Machines
+
+Define per-machine profiles for multi-machine dotfiles setups. Each profile matches by hostname and can override which configs to install and provide default values for machine_config prompts.
+
+```yaml
+machines:
+  - name: Fedora Workstation        # Human-readable name
+    hostname: fedora-workstation    # Matches os.Hostname()
+    exclude_configs: [hyprland]     # Don't install these configs
+    defaults:                       # Default values for machine_config prompts
+      user_email: work@example.com
+
+  - name: CachyOS Laptop
+    hostname: cachyos-laptop
+    exclude_configs: [kde]
+    defaults:
+      user_email: personal@example.com
+
+  - name: MacBook
+    hostname: macbook-pro
+    include_configs: [git, tmux, nvim]  # Only install these configs
+    defaults:
+      user_email: work@example.com
+```
+
+**Fields:**
+- `name`: Human-readable machine name (shown during install).
+- `hostname`: Machine hostname to match. Supports comma-separated values for multiple hostnames.
+- `include_configs`: If set, only these configs are installed. If empty, all configs are included.
+- `exclude_configs`: These configs are never installed on this machine.
+- `defaults`: Key-value map of default values for machine_config prompts. Overrides auto-detected defaults but still allows user to change interactively.
+
+**Condition keys** (used in `condition` maps on configs, dependencies, and external deps):
+- `os` / `platform`: linux, darwin, windows
+- `distro`: fedora, ubuntu, cachyos, arch, etc.
+- `hostname`: Machine hostname (supports comma-separated list)
+- `arch` / `architecture`: amd64, arm64, etc.
+- `package_manager`: dnf, apt, brew, pacman, etc.
+- `wsl`: true, false
 
 ### Post Install
 

--- a/examples/advanced/.go4dot.yaml
+++ b/examples/advanced/.go4dot.yaml
@@ -41,7 +41,7 @@ configs:
       description: Git configuration
       platforms: [linux, darwin]
       requires_machine_config: true
-    
+
     - name: tmux
       path: tmux
       description: Tmux configuration
@@ -54,6 +54,38 @@ configs:
       description: Neovim configuration (IDE-like)
       platforms: [linux, darwin]
       depends_on: [neovim, ripgrep, fd]
+
+    - name: kde
+      path: kde
+      description: KDE Plasma settings
+      condition:
+        hostname: fedora-workstation
+
+    - name: hyprland
+      path: hyprland
+      description: Hyprland window manager
+      condition:
+        distro: cachyos
+
+# Machine profiles for per-host overrides
+machines:
+  - name: Fedora Workstation
+    hostname: fedora-workstation
+    exclude_configs: [hyprland]
+    defaults:
+      user_email: work@example.com
+
+  - name: CachyOS Laptop
+    hostname: cachyos-laptop
+    exclude_configs: [kde]
+    defaults:
+      user_email: personal@example.com
+
+  - name: MacBook
+    hostname: macbook-pro
+    include_configs: [git, tmux, nvim]
+    defaults:
+      user_email: work@example.com
 
 external:
   - name: Tmux Plugin Manager

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -8,6 +8,7 @@ type Config struct {
 	Configs       ConfigGroups    `yaml:"configs"`
 	External      []ExternalDep   `yaml:"external"`
 	MachineConfig []MachinePrompt `yaml:"machine_config"`
+	Machines      []MachineProfile `yaml:"machines"`
 	Archived      []ConfigItem    `yaml:"archived"`
 	PostInstall   string          `yaml:"post_install"`
 }
@@ -37,6 +38,7 @@ type DependencyItem struct {
 	Version    string            `yaml:"version"`     // Required version (e.g. "0.11+")
 	VersionCmd string            `yaml:"version_cmd"` // Command to check version (defaults to --version)
 	Manual     bool              `yaml:"manual"`      // If true, skip automated install (user must install manually)
+	Condition  map[string]string `yaml:"condition"`   // Platform/machine conditions for this dependency
 }
 
 // UnmarshalYAML allows DependencyItem to accept both string and object formats
@@ -62,13 +64,14 @@ type ConfigGroups struct {
 
 // ConfigItem represents a single dotfile configuration
 type ConfigItem struct {
-	Name                  string        `yaml:"name"`
-	Path                  string        `yaml:"path"`
-	Description           string        `yaml:"description"`
-	Platforms             []string      `yaml:"platforms"`
-	DependsOn             []string      `yaml:"depends_on"`
-	ExternalDeps          []ExternalDep `yaml:"external_deps,omitempty"`
-	RequiresMachineConfig bool          `yaml:"requires_machine_config"`
+	Name                  string            `yaml:"name"`
+	Path                  string            `yaml:"path"`
+	Description           string            `yaml:"description"`
+	Platforms             []string          `yaml:"platforms"`
+	Condition             map[string]string `yaml:"condition"`  // Platform/machine conditions (more flexible than platforms)
+	DependsOn             []string          `yaml:"depends_on"`
+	ExternalDeps          []ExternalDep     `yaml:"external_deps,omitempty"`
+	RequiresMachineConfig bool              `yaml:"requires_machine_config"`
 }
 
 // ExternalDep represents an external dependency to clone (plugins, themes, etc.)
@@ -89,6 +92,15 @@ type MachinePrompt struct {
 	Destination string        `yaml:"destination"`
 	Prompts     []PromptField `yaml:"prompts"`
 	Template    string        `yaml:"template"`
+}
+
+// MachineProfile defines per-machine overrides for multi-machine dotfiles
+type MachineProfile struct {
+	Name           string            `yaml:"name"`            // Human-readable machine name
+	Hostname       string            `yaml:"hostname"`        // Hostname to match (supports comma-separated)
+	IncludeConfigs []string          `yaml:"include_configs"` // Config names to include (empty = all)
+	ExcludeConfigs []string          `yaml:"exclude_configs"` // Config names to exclude
+	Defaults       map[string]string `yaml:"defaults"`        // Default values for machine_config prompts
 }
 
 // PromptField represents a single prompt for user input

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nvandessel/go4dot/internal/platform"
 	"github.com/nvandessel/go4dot/internal/validation"
 )
 
@@ -230,6 +231,108 @@ func (c *Config) GetConfigByName(name string) *ConfigItem {
 		}
 	}
 	return nil
+}
+
+// GetConfigsForPlatform returns configs filtered by platform conditions and machine profile.
+// It checks both the legacy Platforms field and the new Condition field.
+func (c *Config) GetConfigsForPlatform(p *platform.Platform) []ConfigItem {
+	all := c.GetAllConfigs()
+	profile := c.GetMachineProfile(p.Hostname)
+
+	var filtered []ConfigItem
+	for _, cfg := range all {
+		if !configMatchesPlatform(cfg, p) {
+			continue
+		}
+		if profile != nil && !profileIncludesConfig(profile, cfg.Name) {
+			continue
+		}
+		filtered = append(filtered, cfg)
+	}
+	return filtered
+}
+
+// GetDepsForPlatform returns dependencies filtered by platform conditions.
+func (c *Config) GetDepsForPlatform(p *platform.Platform) Dependencies {
+	return Dependencies{
+		Critical: filterDeps(c.Dependencies.Critical, p),
+		Core:     filterDeps(c.Dependencies.Core, p),
+		Optional: filterDeps(c.Dependencies.Optional, p),
+	}
+}
+
+// GetMachineProfile returns the machine profile matching the given hostname, or nil.
+func (c *Config) GetMachineProfile(hostname string) *MachineProfile {
+	if hostname == "" {
+		return nil
+	}
+	for i, m := range c.Machines {
+		// Support comma-separated hostnames in the profile
+		for _, h := range strings.Split(m.Hostname, ",") {
+			if strings.TrimSpace(h) == hostname {
+				return &c.Machines[i]
+			}
+		}
+	}
+	return nil
+}
+
+// configMatchesPlatform checks if a config matches the current platform.
+// Checks both legacy Platforms field and Condition field.
+func configMatchesPlatform(cfg ConfigItem, p *platform.Platform) bool {
+	// Check legacy Platforms field
+	if len(cfg.Platforms) > 0 {
+		matched := false
+		for _, plat := range cfg.Platforms {
+			if plat == p.OS || plat == "all" || plat == p.Distro {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	// Check Condition field
+	if len(cfg.Condition) > 0 {
+		if !platform.CheckCondition(cfg.Condition, p) {
+			return false
+		}
+	}
+	return true
+}
+
+// profileIncludesConfig checks if a machine profile includes the given config.
+func profileIncludesConfig(profile *MachineProfile, configName string) bool {
+	// If exclude list has this config, reject it
+	for _, name := range profile.ExcludeConfigs {
+		if name == configName {
+			return false
+		}
+	}
+	// If include list is empty, include all (minus excludes)
+	if len(profile.IncludeConfigs) == 0 {
+		return true
+	}
+	// Check include list
+	for _, name := range profile.IncludeConfigs {
+		if name == configName {
+			return true
+		}
+	}
+	return false
+}
+
+// filterDeps filters a dependency slice by platform conditions.
+func filterDeps(deps []DependencyItem, p *platform.Platform) []DependencyItem {
+	var filtered []DependencyItem
+	for _, dep := range deps {
+		if len(dep.Condition) > 0 && !platform.CheckCondition(dep.Condition, p) {
+			continue
+		}
+		filtered = append(filtered, dep)
+	}
+	return filtered
 }
 
 // validateConfigPath validates a single config path

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"testing"
+
+	"github.com/nvandessel/go4dot/internal/platform"
 )
 
 func TestValidate(t *testing.T) {
@@ -474,6 +476,238 @@ func TestValidate_SecurityValidConfigsStillPass(t *testing.T) {
 
 	if err := cfg.Validate(tempDir); err != nil {
 		t.Errorf("Validate() unexpected error for valid config: %v", err)
+	}
+}
+
+func TestGetConfigsForPlatform(t *testing.T) {
+	cfg := &Config{
+		Configs: ConfigGroups{
+			Core: []ConfigItem{
+				{Name: "git", Path: "git"},
+				{Name: "kde", Path: "kde", Condition: map[string]string{"hostname": "fedora-laptop"}},
+			},
+			Optional: []ConfigItem{
+				{Name: "i3", Path: "i3", Platforms: []string{"linux"}},
+				{Name: "nvim", Path: "nvim"},
+				{Name: "hyprland", Path: "hyprland", Condition: map[string]string{"distro": "cachyos"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		platform *platform.Platform
+		want     []string
+	}{
+		{
+			name:     "fedora laptop gets git, kde, i3, nvim",
+			platform: &platform.Platform{OS: "linux", Distro: "fedora", Hostname: "fedora-laptop"},
+			want:     []string{"git", "kde", "i3", "nvim"},
+		},
+		{
+			name:     "cachyos laptop gets git, i3, nvim, hyprland",
+			platform: &platform.Platform{OS: "linux", Distro: "cachyos", Hostname: "cachyos-laptop"},
+			want:     []string{"git", "i3", "nvim", "hyprland"},
+		},
+		{
+			name:     "macos gets git and nvim only",
+			platform: &platform.Platform{OS: "darwin", Hostname: "macbook"},
+			want:     []string{"git", "nvim"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetConfigsForPlatform(tt.platform)
+			var names []string
+			for _, c := range got {
+				names = append(names, c.Name)
+			}
+			if len(names) != len(tt.want) {
+				t.Errorf("GetConfigsForPlatform() got %v, want %v", names, tt.want)
+				return
+			}
+			for i, name := range names {
+				if name != tt.want[i] {
+					t.Errorf("GetConfigsForPlatform() got %v, want %v", names, tt.want)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestGetConfigsForPlatform_WithMachineProfile(t *testing.T) {
+	cfg := &Config{
+		Configs: ConfigGroups{
+			Core: []ConfigItem{
+				{Name: "git", Path: "git"},
+				{Name: "zsh", Path: "zsh"},
+			},
+			Optional: []ConfigItem{
+				{Name: "i3", Path: "i3"},
+				{Name: "nvim", Path: "nvim"},
+			},
+		},
+		Machines: []MachineProfile{
+			{
+				Name:           "Work Laptop",
+				Hostname:       "work-laptop",
+				IncludeConfigs: []string{"git", "zsh", "nvim"},
+			},
+			{
+				Name:           "Home Desktop",
+				Hostname:       "home-desktop",
+				ExcludeConfigs: []string{"i3"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		platform *platform.Platform
+		want     []string
+	}{
+		{
+			name:     "work laptop gets only included configs",
+			platform: &platform.Platform{OS: "linux", Hostname: "work-laptop"},
+			want:     []string{"git", "zsh", "nvim"},
+		},
+		{
+			name:     "home desktop gets all except excluded",
+			platform: &platform.Platform{OS: "linux", Hostname: "home-desktop"},
+			want:     []string{"git", "zsh", "nvim"},
+		},
+		{
+			name:     "unknown machine gets all configs",
+			platform: &platform.Platform{OS: "linux", Hostname: "unknown"},
+			want:     []string{"git", "zsh", "i3", "nvim"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetConfigsForPlatform(tt.platform)
+			var names []string
+			for _, c := range got {
+				names = append(names, c.Name)
+			}
+			if len(names) != len(tt.want) {
+				t.Errorf("GetConfigsForPlatform() got %v, want %v", names, tt.want)
+				return
+			}
+			for i, name := range names {
+				if name != tt.want[i] {
+					t.Errorf("GetConfigsForPlatform() got %v, want %v", names, tt.want)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestGetDepsForPlatform(t *testing.T) {
+	cfg := &Config{
+		Dependencies: Dependencies{
+			Critical: []DependencyItem{
+				{Name: "git"},
+				{Name: "stow"},
+			},
+			Core: []DependencyItem{
+				{Name: "zsh"},
+				{Name: "plasma-desktop", Condition: map[string]string{"distro": "fedora"}},
+				{Name: "hyprland", Condition: map[string]string{"hostname": "cachyos-laptop"}},
+			},
+			Optional: []DependencyItem{
+				{Name: "ripgrep"},
+				{Name: "brew-only", Condition: map[string]string{"os": "darwin"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		platform      *platform.Platform
+		wantCritical  int
+		wantCore      int
+		wantOptional  int
+	}{
+		{
+			name:         "fedora laptop",
+			platform:     &platform.Platform{OS: "linux", Distro: "fedora", Hostname: "fedora-laptop"},
+			wantCritical: 2,
+			wantCore:     2, // zsh + plasma-desktop
+			wantOptional: 1, // ripgrep (not brew-only)
+		},
+		{
+			name:         "cachyos laptop",
+			platform:     &platform.Platform{OS: "linux", Distro: "cachyos", Hostname: "cachyos-laptop"},
+			wantCritical: 2,
+			wantCore:     2, // zsh + hyprland
+			wantOptional: 1,
+		},
+		{
+			name:         "macOS",
+			platform:     &platform.Platform{OS: "darwin", Hostname: "macbook"},
+			wantCritical: 2,
+			wantCore:     1, // just zsh
+			wantOptional: 2, // ripgrep + brew-only
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetDepsForPlatform(tt.platform)
+			if len(got.Critical) != tt.wantCritical {
+				t.Errorf("critical deps: got %d, want %d", len(got.Critical), tt.wantCritical)
+			}
+			if len(got.Core) != tt.wantCore {
+				t.Errorf("core deps: got %d, want %d", len(got.Core), tt.wantCore)
+			}
+			if len(got.Optional) != tt.wantOptional {
+				t.Errorf("optional deps: got %d, want %d", len(got.Optional), tt.wantOptional)
+			}
+		})
+	}
+}
+
+func TestGetMachineProfile(t *testing.T) {
+	cfg := &Config{
+		Machines: []MachineProfile{
+			{Name: "Laptop", Hostname: "my-laptop"},
+			{Name: "Both", Hostname: "desktop-1,desktop-2"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		hostname string
+		wantName string
+		wantNil  bool
+	}{
+		{name: "exact match", hostname: "my-laptop", wantName: "Laptop"},
+		{name: "comma first", hostname: "desktop-1", wantName: "Both"},
+		{name: "comma second", hostname: "desktop-2", wantName: "Both"},
+		{name: "no match", hostname: "unknown", wantNil: true},
+		{name: "empty hostname", hostname: "", wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetMachineProfile(tt.hostname)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("GetMachineProfile() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("GetMachineProfile() = nil, want non-nil")
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("GetMachineProfile().Name = %s, want %s", got.Name, tt.wantName)
+			}
+		})
 	}
 }
 

--- a/internal/machine/prompts.go
+++ b/internal/machine/prompts.go
@@ -40,10 +40,11 @@ type PromptResult struct {
 
 // PromptOptions configures prompt behavior
 type PromptOptions struct {
-	In           io.Reader                            // Input source (defaults to os.Stdin)
-	Out          io.Writer                            // Output destination (defaults to os.Stdout)
-	ProgressFunc func(current, total int, msg string) // Called for progress updates with item counts
-	SkipPrompts  bool                                 // Use defaults without prompting
+	In              io.Reader                            // Input source (defaults to os.Stdin)
+	Out             io.Writer                            // Output destination (defaults to os.Stdout)
+	ProgressFunc    func(current, total int, msg string) // Called for progress updates with item counts
+	SkipPrompts     bool                                 // Use defaults without prompting
+	ProfileDefaults map[string]string                    // Per-machine default values from machine profile
 }
 
 // CollectMachineConfig prompts the user for all machine-specific values
@@ -138,6 +139,15 @@ func ResolveDefaults(mc config.MachinePrompt) config.MachinePrompt {
 // collectPrompts collects values for a single MachinePrompt using Huh forms
 func collectPrompts(mc config.MachinePrompt, opts PromptOptions) (PromptResult, error) {
 	mc = ResolveDefaults(mc) // enrich before building form
+
+	// Apply machine profile defaults (override auto-detected defaults)
+	if len(opts.ProfileDefaults) > 0 {
+		for i := range mc.Prompts {
+			if val, ok := opts.ProfileDefaults[mc.Prompts[i].ID]; ok {
+				mc.Prompts[i].Default = val
+			}
+		}
+	}
 
 	result := PromptResult{
 		ID:     mc.ID,

--- a/internal/platform/condition.go
+++ b/internal/platform/condition.go
@@ -11,6 +11,7 @@ import (
 // - package_manager: dnf, apt, brew, pacman, etc.
 // - wsl: true, false
 // - arch, architecture: amd64, arm64, etc.
+// - hostname: machine hostname (supports comma-separated list)
 func CheckCondition(condition map[string]string, p *Platform) bool {
 	if len(condition) == 0 {
 		return true // No condition means always true
@@ -39,6 +40,10 @@ func CheckCondition(condition map[string]string, p *Platform) bool {
 			}
 		case "arch", "architecture":
 			if !matchesValue(p.Architecture, value) {
+				return false
+			}
+		case "hostname":
+			if !matchesValue(p.Hostname, value) {
 				return false
 			}
 		}

--- a/internal/platform/condition_test.go
+++ b/internal/platform/condition_test.go
@@ -126,6 +126,42 @@ func TestCheckCondition(t *testing.T) {
 			want:      false,
 		},
 		{
+			name:      "matching hostname",
+			condition: map[string]string{"hostname": "my-laptop"},
+			platform:  &Platform{OS: "linux", Hostname: "my-laptop"},
+			want:      true,
+		},
+		{
+			name:      "non-matching hostname",
+			condition: map[string]string{"hostname": "my-laptop"},
+			platform:  &Platform{OS: "linux", Hostname: "work-desktop"},
+			want:      false,
+		},
+		{
+			name:      "comma-separated hostname match",
+			condition: map[string]string{"hostname": "laptop-1,laptop-2"},
+			platform:  &Platform{OS: "linux", Hostname: "laptop-2"},
+			want:      true,
+		},
+		{
+			name:      "hostname with other conditions",
+			condition: map[string]string{"os": "linux", "hostname": "my-laptop"},
+			platform:  &Platform{OS: "linux", Hostname: "my-laptop"},
+			want:      true,
+		},
+		{
+			name:      "hostname match but os mismatch",
+			condition: map[string]string{"os": "darwin", "hostname": "my-laptop"},
+			platform:  &Platform{OS: "linux", Hostname: "my-laptop"},
+			want:      false,
+		},
+		{
+			name:      "empty hostname never matches",
+			condition: map[string]string{"hostname": "my-laptop"},
+			platform:  &Platform{OS: "linux", Hostname: ""},
+			want:      false,
+		},
+		{
 			name:      "unknown condition key ignored",
 			condition: map[string]string{"unknown_key": "value"},
 			platform:  &Platform{OS: "linux"},

--- a/internal/platform/detect.go
+++ b/internal/platform/detect.go
@@ -17,6 +17,7 @@ type Platform struct {
 	IsWSL          bool   // true if running under WSL
 	PackageManager string // dnf, apt, brew, pacman, etc.
 	Architecture   string // amd64, arm64, etc.
+	Hostname       string // machine hostname
 }
 
 // Detect returns the current platform information
@@ -27,6 +28,8 @@ func Detect() (*Platform, error) {
 	}
 
 	p.IsWSL = detectWSL()
+	p.Hostname, _ = os.Hostname()
+
 	switch p.OS {
 	case "linux":
 		if err := detectLinuxDistro(p); err != nil {
@@ -166,6 +169,9 @@ func (p *Platform) String() string {
 
 	fmt.Fprintf(&sb, "\nArchitecture: %s", p.Architecture)
 	fmt.Fprintf(&sb, "\nPackage Manager: %s", p.PackageManager)
+	if p.Hostname != "" {
+		fmt.Fprintf(&sb, "\nHostname: %s", p.Hostname)
+	}
 
 	return sb.String()
 }

--- a/internal/platform/detect_test.go
+++ b/internal/platform/detect_test.go
@@ -35,6 +35,12 @@ func TestDetect(t *testing.T) {
 	if p.Architecture != runtime.GOARCH {
 		t.Errorf("Architecture mismatch: got %s, want %s", p.Architecture, runtime.GOARCH)
 	}
+
+	// Verify hostname is detected
+	expectedHostname, _ := os.Hostname()
+	if p.Hostname != expectedHostname {
+		t.Errorf("Hostname mismatch: got %s, want %s", p.Hostname, expectedHostname)
+	}
 }
 
 func TestPlatformString(t *testing.T) {
@@ -45,12 +51,13 @@ func TestPlatformString(t *testing.T) {
 		IsWSL:          false,
 		PackageManager: "dnf",
 		Architecture:   "amd64",
+		Hostname:       "my-workstation",
 	}
 
 	s := p.String()
 
 	// Check that output contains key information
-	expectedStrings := []string{"linux", "fedora", "43", "dnf", "amd64"}
+	expectedStrings := []string{"linux", "fedora", "43", "dnf", "amd64", "my-workstation"}
 	for _, expected := range expectedStrings {
 		if !strings.Contains(s, expected) {
 			t.Errorf("String() output missing '%s': %s", expected, s)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -61,9 +61,12 @@ func Install(cfg *config.Config, dotfilesPath string, opts InstallOptions) (*Ins
 	result.Platform = p
 	progress(opts, fmt.Sprintf("✓ Platform: %s (%s)", p.OS, p.PackageManager))
 
+	// Filter config and dependencies for this machine
+	filteredCfg := filterConfigForPlatform(cfg, p)
+
 	// Step 2: Check and install dependencies
 	if !opts.SkipDeps {
-		if err := installDependencies(cfg, p, opts, result); err != nil {
+		if err := installDependencies(filteredCfg, p, opts, result); err != nil {
 			result.Errors = append(result.Errors, err)
 			// Don't return - continue with other steps
 		}
@@ -73,7 +76,7 @@ func Install(cfg *config.Config, dotfilesPath string, opts InstallOptions) (*Ins
 
 	// Step 3: Stow configs
 	if !opts.SkipStow {
-		if err := stowConfigs(cfg, dotfilesPath, opts, result); err != nil {
+		if err := stowConfigs(filteredCfg, dotfilesPath, opts, result); err != nil {
 			result.Errors = append(result.Errors, err)
 		}
 	} else {
@@ -82,7 +85,7 @@ func Install(cfg *config.Config, dotfilesPath string, opts InstallOptions) (*Ins
 
 	// Step 4: Clone external dependencies
 	if !opts.SkipExternal {
-		if err := cloneExternal(cfg, dotfilesPath, p, opts, result); err != nil {
+		if err := cloneExternal(filteredCfg, dotfilesPath, p, opts, result); err != nil {
 			result.Errors = append(result.Errors, err)
 		}
 	} else {
@@ -103,7 +106,7 @@ func Install(cfg *config.Config, dotfilesPath string, opts InstallOptions) (*Ins
 
 	// Step 6: Configure machine-specific settings
 	if !opts.SkipMachine {
-		if err := configureMachine(cfg, opts, result); err != nil {
+		if err := configureMachine(filteredCfg, p, opts, result); err != nil {
 			result.Errors = append(result.Errors, err)
 		}
 	} else {
@@ -159,7 +162,7 @@ func installDependencies(cfg *config.Config, p *platform.Platform, opts InstallO
 func stowConfigs(cfg *config.Config, dotfilesPath string, opts InstallOptions, result *InstallResult) error {
 	progress(opts, "\n── Configs ──")
 
-	// Get configs to stow
+	// Get configs to stow (already filtered by platform in Install())
 	var configs []config.ConfigItem
 	if opts.Minimal {
 		configs = cfg.Configs.Core
@@ -307,7 +310,7 @@ func setupKeys(opts InstallOptions, result *InstallResult) error {
 }
 
 // configureMachine configures machine-specific settings
-func configureMachine(cfg *config.Config, opts InstallOptions, result *InstallResult) error {
+func configureMachine(cfg *config.Config, p *platform.Platform, opts InstallOptions, result *InstallResult) error {
 	if len(cfg.MachineConfig) == 0 {
 		return nil
 	}
@@ -334,8 +337,18 @@ func configureMachine(cfg *config.Config, opts InstallOptions, result *InstallRe
 
 	progress(opts, fmt.Sprintf("Configuring %d machine settings...", len(needsConfig)))
 
+	// Get machine profile defaults if available
+	var profileDefaults map[string]string
+	if profile := cfg.GetMachineProfile(p.Hostname); profile != nil {
+		profileDefaults = profile.Defaults
+		if profile.Name != "" {
+			progress(opts, fmt.Sprintf("Machine profile: %s", profile.Name))
+		}
+	}
+
 	promptOpts := machine.PromptOptions{
-		SkipPrompts: opts.Auto,
+		SkipPrompts:     opts.Auto,
+		ProfileDefaults: profileDefaults,
 		ProgressFunc: func(current, total int, msg string) {
 			progressWithCount(opts, current, total, "  "+msg)
 		},
@@ -384,6 +397,28 @@ func progressWithCount(opts InstallOptions, current, total int, msg string) {
 	if opts.ProgressFunc != nil {
 		opts.ProgressFunc(current, total, msg)
 	}
+}
+
+// filterConfigForPlatform returns a copy of the config with deps and configs filtered for the current platform.
+func filterConfigForPlatform(cfg *config.Config, p *platform.Platform) *config.Config {
+	filtered := *cfg
+	filtered.Dependencies = cfg.GetDepsForPlatform(p)
+	filteredConfigs := cfg.GetConfigsForPlatform(p)
+
+	// Rebuild core/optional split
+	coreNames := make(map[string]bool)
+	for _, c := range cfg.Configs.Core {
+		coreNames[c.Name] = true
+	}
+	filtered.Configs = config.ConfigGroups{}
+	for _, c := range filteredConfigs {
+		if coreNames[c.Name] {
+			filtered.Configs.Core = append(filtered.Configs.Core, c)
+		} else {
+			filtered.Configs.Optional = append(filtered.Configs.Optional, c)
+		}
+	}
+	return &filtered
 }
 
 // Summary returns a human-readable summary of the installation result


### PR DESCRIPTION
## Summary
- Add multi-machine dotfiles support with platform conditions and config validation
- New validator for config schema, platform condition detection, and setup improvements
- 12 files changed (+573, -21)

Source issue: go4dot-9wa.3
MR: go-wisp-49t4
Worker: shiny

**Tests**: All changed-package tests pass. Pre-existing flaky test `TestDashboard_MenuNavigation` tracked in go-5mk.

Merged by Refinery (go4dot/refinery)